### PR TITLE
Remove white chars per line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,8 @@ module.exports = (xml, indent) => {
   indent = indent || '    ';
 
   return splitOnTags(xml).map(item => {
+    // removes any pre-existing whitespace chars at the end or beginning of the item
+    item = item.replace(/^\s+|\s+$/g, '');
     if (isClosingTag(item)) {
       depth--;
     }

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -47,6 +47,21 @@ test('text nodes', assert => {
   assert.end();
 });
 
+test('text nodes don\'t duplicate whitespace on more than one execution', assert => {
+  const actual = beautify(beautify(`<div><span>
+foo bar
+</span></div>`));
+  const expected =
+`<div>
+    <span>
+        foo bar
+    </span>
+</div>`;
+
+  assert.equal(actual, expected, 'should indent text nodes correctly with no duplicated whitespaces');
+  assert.end();
+});
+
 test('tags containing "/"', assert => {
   const actual = beautify('<div><a href="/">foo bar</a></div>');
   const expected =


### PR DESCRIPTION
removes any pre-existing whitespace chars at the end or beginning of the lines on running beautify more than one time to avoid this:
![3my5wa](https://user-images.githubusercontent.com/1237997/72977341-9deae700-3dd4-11ea-90c9-e90098f1d6fb.gif)
